### PR TITLE
Update CI workflow to exclude Python 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.x", "3.12", "3.11"]
+        python-version: ["3.x", "3.12"]
       fail-fast: false
 
     steps:


### PR DESCRIPTION
Removed Python 3.11 from the CI workflow matrix.